### PR TITLE
New README with some examples, run command fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Debian/Ubuntu:
 ```
 
 ## Usage
-- type ```python share-online.py -h``` for help message
+- type ```python3 share-online.py -h``` for help message
 - optional arguments:
 
         -s      the number of download-slots to use (e.g. parallel executed downloads)
@@ -28,7 +28,7 @@ Debian/Ubuntu:
 - positional arguments:
 
         - linkListFileName      file-name with share-online links, see link-ids-TEMPLATE.txt
-        - Example:              # python share-online.py links.txt
+        - Example:              # python3 share-online.py links.txt
 
 ## Grabbing link-ids:
 Copy content of DLC-file and decrypt it here: [dcrypt.it](http://dcrypt.it/) to get links via Click'n'Load you can use this script: [https://github.com/drwilly/clicknload2text](https://github.com/drwilly/clicknload2text).

--- a/README.md
+++ b/README.md
@@ -1,0 +1,36 @@
+# share-online-pyloader
+Terminal downloader for [share-online.biz](http://www.share-online.biz/) premium members.
+
+This python-script enables you to download content via terminal from [share-online.biz](http://www.share-online.biz/) with your premium-account, for example if you want to run some downloads but only have termial-access to a remote computer. It can be seen as a simple and light-weight alternative to jDownloader, pyLoad, aria2 etc.
+See license for legal restrictions.
+
+## Setup
+- well, a valid share-online premium-account (enter username and password inside the script)
+- python3 (you maybe have to install python3-requests)
+- curl
+- unrar (if you want to extract files after downloading)
+
+Debian/Ubuntu:
+```sh
+# sudo apt-get install curl python3 unrar-free
+# git clone https://github.com/DirtyDan88/share-online-pyloader.git
+# cd share-online-pyloader
+# python share-online.py -h
+```
+
+## Usage
+- type ```python share-online.py -h``` for help message
+- optional arguments:
+
+        -s      the number of download-slots to use (e.g. parallel executed downloads)
+        -e      extract files after download
+        -p      password for archieves (only when -e is present)
+- positional arguments:
+
+        - linkListFileName      file-name with share-online links, see link-ids-TEMPLATE.txt
+        - Example:              # python share-online.py links.txt
+
+## Grabbing link-ids:
+Copy content of DLC-file and decrypt it here: [dcrypt.it](http://dcrypt.it/) to get links via Click'n'Load you can use this script: [https://github.com/drwilly/clicknload2text](https://github.com/drwilly/clicknload2text).
+
+Copy the links into a file as shown in link-ids-TEMPLATE.txt and run the downloader. Enjoy!


### PR DESCRIPTION
Run command fix: "python share-online.py ..." works, but "python3 share-online.py ..." doesn't.
